### PR TITLE
removed alert render from application view

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   </head>
   <body>
-    <%= render 'components/flash_messages' %>
     <%= render 'shared/sidebar' %>
     <div class="content">
       <%= yield %>


### PR DESCRIPTION
<img width="908" alt="image" src="https://github.com/user-attachments/assets/643419c6-1320-49f7-bc29-37cdab9eb219">

removed     <%= render 'components/flash_messages' %>