### PR TITLE
change the validation for before_validation

### DIFF
--- a/app/models/collaboration.rb
+++ b/app/models/collaboration.rb
@@ -5,7 +5,7 @@ class Collaboration < ApplicationRecord
   validates :category, inclusion: { in: CATEGORIES }, allow_nil: false
   belongs_to :user
   has_many :submissions, dependent: :destroy
-  before_save :capitalize_title, :capitalize_categories
+  before_validation :capitalize_title, :capitalize_categories
   validate :user_brand
 
   has_one_attached :banner 


### PR DESCRIPTION
Change before_save to before_validation in Collaboration model

I updated the collaboration model to use before_validation callbacks instead of before_save for capitalizing the title and category. This change ensures that validations run on the capitalized values, allowing correct seed creation without errors.
